### PR TITLE
Fix noop parameter with future parser

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,5 +64,5 @@ class ssmtp::params {
   $version = 'present'
   $absent = false
   $audit_only = false
-  $noops = undef
+  $noops = false
 }


### PR DESCRIPTION
The `$noop` parameter must be one of `true` or `false` with the future Puppet parser. Fixes this error:

```
Error: Parameter noop failed on Package[ssmtp]: Invalid value "". Valid values are true, false.  at /.../ssmtp/manifests/init.pp:204
```
